### PR TITLE
Improving FileRepository::yieldByCodepoints performances

### DIFF
--- a/lib/UCD/Infrastructure/Repository/CharacterRepository/FileRepository/FileCache.php
+++ b/lib/UCD/Infrastructure/Repository/CharacterRepository/FileRepository/FileCache.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace UCD\Infrastructure\Repository\CharacterRepository\FileRepository;
+
+class FileCache
+{
+    /**
+     * @var array
+     */
+    private $cache = [];
+
+    /**
+     * @param RangeFile $file
+     * @return string[]
+     */
+    public function read(RangeFile $file) {
+        $filePath = $file->getPath();
+        if (array_key_exists($filePath, $this->cache)) {
+            $characters = $this->cache[$filePath];
+        } else {
+            $characters = $file->read();
+            $this->cache[$filePath] = $characters;
+        }
+
+        return $characters;
+    }
+}

--- a/lib/UCD/Infrastructure/Repository/CharacterRepository/FileRepository/RangeFile.php
+++ b/lib/UCD/Infrastructure/Repository/CharacterRepository/FileRepository/RangeFile.php
@@ -71,4 +71,12 @@ class RangeFile
     {
         return $this->total;
     }
+
+    /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->file->getInfo()->getPathname();
+    }
 }


### PR DESCRIPTION
When reading all characters from a block, the method `FileRepository::yieldByCodepoints` reads one file for every character in the block. The code below takes 23s. Adding a file cache gets this down to 0.29s.

```php
Database::fromDisk()->getByBlock(Block::fromValue('Cuneiform'))->getCharacters()
    ->traverseWith(function (Character $character) {
        echo $character->getGeneralProperties()->getNames()->getPrimary(), PHP_EOL;
    });
```